### PR TITLE
Remove suggestions

### DIFF
--- a/schema/libraries.yml.json
+++ b/schema/libraries.yml.json
@@ -48,7 +48,6 @@
                     "pattern": "^.+/.+$"
                 }
             }
-
         }
     },
     "definitions": {

--- a/schema/links.task.yml.json
+++ b/schema/links.task.yml.json
@@ -14,9 +14,7 @@
             "class": {"type": "string"},
             "cache_tags": {
                 "type": "array",
-                "items": {
-                    "type": "string"
-                }
+                "items": {"type": "string"}
             }
         },
         "additionalProperties": false

--- a/schema/services.yml.json
+++ b/schema/services.yml.json
@@ -27,91 +27,18 @@
                         "items": {
                             "type": "object",
                             "properties": {
-                                "name": {
-                                    "anyOf": [
-                                        {
-                                            "enum": [
-                                                "access_check",
-                                                "authentication_provider",
-                                                "backend_overridable",
-                                                "cache.bin",
-                                                "cache.context",
-                                                "cache_tags_invalidator",
-                                                "context_provider",
-                                                "dynamic_page_cache_response_policy",
-                                                "event_subscriber",
-                                                "http_middleware",
-                                                "mime_type_guesser",
-                                                "needs_destruction",
-                                                "page_cache_request_policy",
-                                                "page_cache_response_policy",
-                                                "paramconverter",
-                                                "parameter_service",
-                                                "path_processor_inbound",
-                                                "path_processor_outbound",
-                                                "persist",
-                                                "placeholder_strategy",
-                                                "plugin_manager_cache_clear",
-                                                "render.main_content_renderer",
-                                                "route_enhancer",
-                                                "route_filter",
-                                                "route_processor_outbound",
-                                                "service_collector",
-                                                "session_handler_proxy",
-                                                "stream_wrapper",
-                                                "string_translator",
-                                                "twig.extension",
-                                                "twig.loader",
-                                                "theme_negotiator",
-                                                "breadcrumb_builder",
-                                                "module_install.uninstall_validator",
-                                                "config.factory.override",
-                                                "drush.command",
-                                                "drupal.command",
-                                                "logger"
-                                            ]
-                                        },
-                                        {"type": "string"}
-                                    ]
-                                },
+                                "name": {"type": "string"},
                                 "call": {"type": "string"},
                                 "required": {"type": "boolean"},
                                 "tag": {"type": "string"},
                                 "priority": {"type": "integer"},
                                 "default_backend": {"type": "string"},
                                 "responder": {"type": "boolean"},
-                                "format": {
-                                    "anyOf": [
-                                        {
-                                            "enum": [
-                                                "html",
-                                                "drupal_ajax",
-                                                "iframeupload",
-                                                "drupal_dialog",
-                                                "drupal_dialog.off_canvas",
-                                                "drupal_dialog.off_canvas_top",
-                                                "drupal_modal"
-                                            ]
-                                        },
-                                        {"type": "string"}
-                                    ]
-                                },
+                                "format": {"type": "string"},
                                 "applies_to": {"type": "string"},
                                 "provider_id": {"type": "string"},
                                 "needs_incoming_request": {"type": "boolean"},
-                                "scheme": {
-                                    "anyOf": [
-                                        {
-                                            "enum": [
-                                                "public",
-                                                "private",
-                                                "temporary"
-
-                                            ]
-                                        },
-                                        {"type": "string"}
-                                    ]
-                                }
+                                "scheme": {"type": "string"}
                             }
                         }
                     },


### PR DESCRIPTION
Turns out PhpStorm already provides autocomplete suggestions for service tags likely with the help of Symfony plugin. Maintaining enumerations for other properties has a little use as they are not widely used.
Also the way they are currently implemented is rather tricky. See https://github.com/json-schema-org/json-schema-spec/issues/751 for details.